### PR TITLE
More enhancements to the join retry flow

### DIFF
--- a/App/Components/ProcessingThread.tsx
+++ b/App/Components/ProcessingThread.tsx
@@ -85,9 +85,13 @@ class ProcessingThread extends React.Component<InboundInvite & DispatchProps & S
       this.props.dismiss(inviteId)
     }
   }
-  retry(inviteId: string, key: string, threadName?: string, inviter?: string) {
-    return () => {
-      this.props.retry(inviteId, key, threadName, inviter)
+  retry(inviteId: string, key: string, type: string, threadName?: string, inviter?: string) {
+    if (type === 'external') {
+      return () => {
+        this.props.retry(inviteId, key, threadName, inviter)
+      }
+    } else {
+        this.props.retryInternal(inviteId, threadName)
     }
   }
   view(inviteId: string, threadId: string, name: string) {
@@ -198,6 +202,7 @@ const mapStateToProps = (state: RootState, ownProps: InboundInvite): StateProps 
 export interface DispatchProps {
   navigateToThread: (id: string, name: string) => void,
   retry: (inviteId: string, key: string, threadName?: string, inviter?: string) => void,
+  retryInternal: (inviteId: string, threadName: string) => void,
   dismiss: (inviteId: string) => void
 }
 
@@ -205,7 +210,8 @@ const mapDispatchToProps = (dispatch: Dispatch<RootAction>): DispatchProps => {
   return {
     navigateToThread: (id: string, name: string) => {dispatch(UIActions.navigateToThreadRequest(id, name))},
     retry: (inviteId: string, key: string, threadName?: string, inviter?: string) => {dispatch(ThreadsActions.acceptExternalInviteRequest(inviteId, key, threadName, inviter))},
-    dismiss: (inviteId: string) => {dispatch(ThreadsActions.acceptExternalInviteDismiss(inviteId))}
+    retryInternal: (inviteId, threadName) => {dispatch(ThreadsActions.acceptInviteRequest(inviteId, threadName))},
+    dismiss: (inviteId: string) => {dispatch(ThreadsActions.acceptInviteDismiss(inviteId))}
   }
 }
 

--- a/App/Components/ProcessingThread.tsx
+++ b/App/Components/ProcessingThread.tsx
@@ -91,7 +91,9 @@ class ProcessingThread extends React.Component<InboundInvite & DispatchProps & S
         this.props.retry(inviteId, key, threadName, inviter)
       }
     } else {
+      return () => {
         this.props.retryInternal(inviteId, threadName)
+      }
     }
   }
   view(inviteId: string, threadId: string, name: string) {
@@ -135,7 +137,7 @@ class ProcessingThread extends React.Component<InboundInvite & DispatchProps & S
   render() {
     const props = this.props
     const dismiss = this.dismiss(this.props.inviteId)
-    const retry = this.retry(this.props.inviteId, this.props.inviteKey, this.props.name, this.props.inviter)
+    const retry = this.retry(this.props.inviteId, this.props.inviteKey, this.props.type, this.props.name, this.props.inviter)
 
     const errorMessage = props.errorMessage
     const message = this.getMessage(props.stage, props.name)

--- a/App/Components/ProcessingThread.tsx
+++ b/App/Components/ProcessingThread.tsx
@@ -85,9 +85,9 @@ class ProcessingThread extends React.Component<InboundInvite & DispatchProps & S
       this.props.dismiss(inviteId)
     }
   }
-  retry(inviteId: string, key: string) {
+  retry(inviteId: string, key: string, threadName?: string, inviter?: string) {
     return () => {
-      this.props.retry(inviteId, key)
+      this.props.retry(inviteId, key, threadName, inviter)
     }
   }
   view(inviteId: string, threadId: string, name: string) {
@@ -131,7 +131,7 @@ class ProcessingThread extends React.Component<InboundInvite & DispatchProps & S
   render() {
     const props = this.props
     const dismiss = this.dismiss(this.props.inviteId)
-    const retry = this.retry(this.props.inviteId, this.props.inviteKey)
+    const retry = this.retry(this.props.inviteId, this.props.inviteKey, this.props.name, this.props.inviter)
 
     const errorMessage = props.errorMessage
     const message = this.getMessage(props.stage, props.name)
@@ -197,14 +197,14 @@ const mapStateToProps = (state: RootState, ownProps: InboundInvite): StateProps 
 
 export interface DispatchProps {
   navigateToThread: (id: string, name: string) => void,
-  retry: (inviteId: string, key: string) => void,
+  retry: (inviteId: string, key: string, threadName?: string, inviter?: string) => void,
   dismiss: (inviteId: string) => void
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<RootAction>): DispatchProps => {
   return {
     navigateToThread: (id: string, name: string) => {dispatch(UIActions.navigateToThreadRequest(id, name))},
-    retry: (inviteId: string, key: string) => {dispatch(ThreadsActions.acceptExternalInviteRequest(inviteId, key))},
+    retry: (inviteId: string, key: string, threadName?: string, inviter?: string) => {dispatch(ThreadsActions.acceptExternalInviteRequest(inviteId, key, threadName, inviter))},
     dismiss: (inviteId: string) => {dispatch(ThreadsActions.acceptExternalInviteDismiss(inviteId))}
   }
 }

--- a/App/Components/ProcessingThread.tsx
+++ b/App/Components/ProcessingThread.tsx
@@ -202,7 +202,7 @@ const mapStateToProps = (state: RootState, ownProps: InboundInvite): StateProps 
 export interface DispatchProps {
   navigateToThread: (id: string, name: string) => void,
   retry: (inviteId: string, key: string, threadName?: string, inviter?: string) => void,
-  retryInternal: (inviteId: string, threadName: string) => void,
+  retryInternal: (inviteId: string, threadName?: string) => void,
   dismiss: (inviteId: string) => void
 }
 
@@ -210,7 +210,7 @@ const mapDispatchToProps = (dispatch: Dispatch<RootAction>): DispatchProps => {
   return {
     navigateToThread: (id: string, name: string) => {dispatch(UIActions.navigateToThreadRequest(id, name))},
     retry: (inviteId: string, key: string, threadName?: string, inviter?: string) => {dispatch(ThreadsActions.acceptExternalInviteRequest(inviteId, key, threadName, inviter))},
-    retryInternal: (inviteId, threadName) => {dispatch(ThreadsActions.acceptInviteRequest(inviteId, threadName))},
+    retryInternal: (inviteId: string, threadName?: string) => {dispatch(ThreadsActions.acceptInviteRequest(inviteId, threadName))},
     dismiss: (inviteId: string) => {dispatch(ThreadsActions.acceptInviteDismiss(inviteId))}
   }
 }

--- a/App/Redux/ThreadsRedux.ts
+++ b/App/Redux/ThreadsRedux.ts
@@ -39,7 +39,7 @@ const actions = {
     return () => resolve()
   }),
   acceptInviteRequest: createAction('ACCEPT_THREAD_NOTIFICATION_INVITE', (resolve) => {
-    return (notificationId: string, threadName: string) => resolve({ notificationId, threadName  })
+    return (notificationId: string, threadName?: string) => resolve({ notificationId, threadName  })
   }),
   addInternalInvitesRequest: createAction('ADD_INTERNAL_INVITES_REQUEST', (resolve) => {
     return (threadId: string, addresses: string[]) => resolve({ threadId, addresses  })

--- a/App/Redux/ThreadsRedux.ts
+++ b/App/Redux/ThreadsRedux.ts
@@ -124,8 +124,12 @@ export function reducer(state: ThreadsState = initialState, action: ThreadsActio
       const { inviteId, key, name, inviter } = action.payload
       const existing = state.inboundInvites.find((obj) => obj.inviteId === inviteId)
       if (existing && !existing.error) {
-        // if the invite already exists and hasn't error'd, return
-        return state
+        // if the invite already exists and hasn't error'd, return ensuring undismiss
+        const inboundInvite = {...existing, dismissed: false}
+        const inboundInvites = state.inboundInvites
+          .filter((inv) => inv.inviteId !== inviteId)
+          .concat([inboundInvite])
+        return { ...state, inboundInvites }
       }
       const stage: InviteStage = 'joining'
       const inboundInvite: InboundInvite = {inviteId, inviteKey: key, name, inviter, stage}

--- a/App/Redux/ThreadsRedux.ts
+++ b/App/Redux/ThreadsRedux.ts
@@ -20,7 +20,7 @@ const actions = {
   acceptExternalInviteRequest: createAction('ACCEPT_EXTERNAL_THREAD_INVITE', (resolve) => {
     return (inviteId: string, key: string, name?: string, inviter?: string) => resolve({ inviteId, key, name, inviter })
   }),
-  acceptExternalInviteDismiss: createAction('ACCEPT_EXTERNAL_THREAD_INVITE_DISMISS', (resolve) => {
+  acceptInviteDismiss: createAction('ACCEPT_EXTERNAL_THREAD_INVITE_DISMISS', (resolve) => {
     return (inviteId: string) => resolve({inviteId})
   }),
   acceptInviteScanning: createAction('ACCEPT_EXTERNAL_THREAD_INVITE_SCANNING', (resolve) => {
@@ -187,7 +187,7 @@ export function reducer(state: ThreadsState = initialState, action: ThreadsActio
       )
       return { ...state, inboundInvites }
     }
-    case getType(actions.acceptExternalInviteDismiss): {
+    case getType(actions.acceptInviteDismiss): {
       const { inviteId } = action.payload
       // update the inbound invite with the new thread id object
       const inboundInvites = state.inboundInvites.map(

--- a/App/Redux/__tests__/ThreadsRedux.ts
+++ b/App/Redux/__tests__/ThreadsRedux.ts
@@ -37,7 +37,7 @@ describe('ui stories', () => {
       const state0 = reducer(initialState, actions.acceptExternalInviteRequest(inviteId, inviteKey))
       const match0 = [{ inviteId, inviteKey }]
       expect(state0.inboundInvites).toMatchObject(match0)
-      const state1 = reducer(state0, actions.acceptExternalInviteSuccess(inviteId, id))
+      const state1 = reducer(state0, actions.acceptInviteSuccess(inviteId, id))
       const match1 = [{ inviteId, inviteKey, id }]
       expect(state1.inboundInvites).toMatchObject(match1)
     })
@@ -45,7 +45,7 @@ describe('ui stories', () => {
       const state0 = reducer(initialState, actions.acceptExternalInviteRequest(inviteId, inviteKey))
       const match0 = [{ inviteId, inviteKey }]
       expect(state0.inboundInvites).toMatchObject(match0)
-      const state1 = reducer(state0, actions.acceptExternalInviteError(inviteId, error))
+      const state1 = reducer(state0, actions.acceptInviteError(inviteId, error))
       const match1 = [{ inviteId, inviteKey, error }]
       expect(state1.inboundInvites).toMatchObject(match1)
     })
@@ -54,9 +54,9 @@ describe('ui stories', () => {
       expect(state0).toMatchObject(initialState)
       const state1 = reducer(initialState, actions.addExternalInviteError(id, error))
       expect(state1).toMatchObject(initialState)
-      const state2 = reducer(initialState, actions.acceptExternalInviteSuccess(inviteId, id))
+      const state2 = reducer(initialState, actions.acceptInviteSuccess(inviteId, id))
       expect(state2).toMatchObject(initialState)
-      const state3 = reducer(initialState, actions.acceptExternalInviteError(inviteId, error))
+      const state3 = reducer(initialState, actions.acceptInviteError(inviteId, error))
       expect(state3).toMatchObject(initialState)
     })
   })

--- a/App/Sagas/ThreadsSagas.ts
+++ b/App/Sagas/ThreadsSagas.ts
@@ -55,23 +55,36 @@ export function * presentShareInterface(action: ActionType<typeof ThreadsActions
   yield call(Share.share, { title: 'Join my thread on Textile!', message: link })
 }
 
-export function * acceptExternalInvite(action: ActionType<typeof ThreadsActions.acceptExternalInviteRequest>) {
-  yield fork(processExternalInvite, action)
-}
 
-function * joinOnFork(inviteId: string, key: string) {
+export function * acceptInvite(action: ActionType<typeof ThreadsActions.acceptInviteRequest>) {
+  const { notificationId, threadName } = action.payload
   try {
-    // our forked job needs to stay alive so we can get any error message
-    const joinId = yield call(API.invites.acceptExternal, inviteId, key)
-    // if success, trigger complete and update ui
-    yield put(ThreadsActions.acceptExternalInviteSuccess(inviteId, joinId))
+    // don't wait for the join event here...
+    yield call(waitUntilOnline, 5000)
+    // We'll fork this so that we can Update the UI so user can perceive progress
+    yield fork(joinInternalOnFork, notificationId, threadName)
+    yield call(delay, 900)
+    // After delay, we'll assume we are walking back through the thread... enhancement later
+    yield put(ThreadsActions.acceptInviteScanning(notificationId))
+    // Refresh in case the head is available
     yield put(PhotoViewingActions.refreshThreadsRequest())
   } catch (error) {
-    yield put(ThreadsActions.acceptExternalInviteError(inviteId, error))
+    yield put(ThreadsActions.acceptInviteError(notificationId, error))
   }
 }
 
-function * processExternalInvite(action: ActionType<typeof ThreadsActions.acceptExternalInviteRequest>) {
+function * joinInternalOnFork(notificationId: string, threadName: string) {
+  try {
+    const threadId = yield call(API.notifications.acceptInvite, notificationId)
+    yield put(PhotoViewingActions.refreshThreadsRequest())
+    yield put(ThreadsActions.acceptInviteSuccess(notificationId, threadId))
+    yield put(UIActions.navigateToThreadRequest(threadId, threadName))
+  } catch (error) {
+    yield put(ThreadsActions.acceptInviteError(notificationId, error))
+  }
+}
+
+export function * acceptExternalInvite(action: ActionType<typeof ThreadsActions.acceptExternalInviteRequest>) {
   const { inviteId, key } = action.payload
   try {
     // don't wait for the join event here...
@@ -80,11 +93,23 @@ function * processExternalInvite(action: ActionType<typeof ThreadsActions.accept
     yield fork(joinOnFork, inviteId, key)
     yield call(delay, 900)
     // After delay, we'll assume we are walking back through the thread... enhancement later
-    yield put(ThreadsActions.acceptExternalInviteScanning(inviteId))
+    yield put(ThreadsActions.acceptInviteScanning(inviteId))
     // Refresh in case the head is available
     yield put(PhotoViewingActions.refreshThreadsRequest())
   } catch (error) {
-    yield put(ThreadsActions.acceptExternalInviteError(inviteId, error))
+    yield put(ThreadsActions.acceptInviteError(inviteId, error))
+  }
+}
+
+function * joinOnFork(inviteId: string, key: string) {
+  try {
+    // our forked job needs to stay alive so we can get any error message
+    const joinId = yield call(API.invites.acceptExternal, inviteId, key)
+    // if success, trigger complete and update ui
+    yield put(ThreadsActions.acceptInviteSuccess(inviteId, joinId))
+    yield put(PhotoViewingActions.refreshThreadsRequest())
+  } catch (error) {
+    yield put(ThreadsActions.acceptInviteError(inviteId, error))
   }
 }
 
@@ -119,17 +144,6 @@ export function * cameraRollThreadCreateTask() {
     yield call(API.threads.add, config)
   } catch (error) {
     // TODO: the camera sync relies on this tread existing, so if any other besides UNIQUE constraint, we should try again
-  }
-}
-
-export function * acceptInvite(action: ActionType<typeof ThreadsActions.acceptInviteRequest>) {
-  const { notificationId, threadName } = action.payload
-  try {
-    const threadId = yield call(API.notifications.acceptInvite, notificationId)
-    yield put(PhotoViewingActions.refreshThreadsRequest())
-    yield put(UIActions.navigateToThreadRequest(threadId, threadName))
-  } catch (error) {
-    // TODO: it would be nice to tell the user when they've already joined the thread
   }
 }
 

--- a/App/Sagas/ThreadsSagas.ts
+++ b/App/Sagas/ThreadsSagas.ts
@@ -67,6 +67,7 @@ export function * acceptInvite(action: ActionType<typeof ThreadsActions.acceptIn
     yield put(ThreadsActions.acceptInviteScanning(notificationId))
     // Refresh in case the head is available
     yield put(PhotoViewingActions.refreshThreadsRequest())
+    yield call(NavigationService.navigate, 'Groups')
   } catch (error) {
     yield put(ThreadsActions.acceptInviteError(notificationId, error))
   }
@@ -77,6 +78,8 @@ function * joinInternalOnFork(notificationId: string, threadName?: string) {
     const threadId = yield call(API.notifications.acceptInvite, notificationId)
     yield put(PhotoViewingActions.refreshThreadsRequest())
     yield put(ThreadsActions.acceptInviteSuccess(notificationId, threadId))
+    // nice with a bit of delay so the app can grab some blocks
+    yield call(delay, 500)
     yield put(UIActions.navigateToThreadRequest(threadId, threadName || 'Processing...'))
   } catch (error) {
     yield put(ThreadsActions.acceptInviteError(notificationId, error))

--- a/App/Sagas/ThreadsSagas.ts
+++ b/App/Sagas/ThreadsSagas.ts
@@ -72,12 +72,12 @@ export function * acceptInvite(action: ActionType<typeof ThreadsActions.acceptIn
   }
 }
 
-function * joinInternalOnFork(notificationId: string, threadName: string) {
+function * joinInternalOnFork(notificationId: string, threadName?: string) {
   try {
     const threadId = yield call(API.notifications.acceptInvite, notificationId)
     yield put(PhotoViewingActions.refreshThreadsRequest())
     yield put(ThreadsActions.acceptInviteSuccess(notificationId, threadId))
-    yield put(UIActions.navigateToThreadRequest(threadId, threadName))
+    yield put(UIActions.navigateToThreadRequest(threadId, threadName || 'Processing...'))
   } catch (error) {
     yield put(ThreadsActions.acceptInviteError(notificationId, error))
   }

--- a/App/Sagas/ThreadsSagas.ts
+++ b/App/Sagas/ThreadsSagas.ts
@@ -55,7 +55,6 @@ export function * presentShareInterface(action: ActionType<typeof ThreadsActions
   yield call(Share.share, { title: 'Join my thread on Textile!', message: link })
 }
 
-
 export function * acceptInvite(action: ActionType<typeof ThreadsActions.acceptInviteRequest>) {
   const { notificationId, threadName } = action.payload
   try {


### PR DESCRIPTION
Couple things I saw playing more with it.

- Remembers threadName on a retry request
- If progress was dismissed and then user tries to accept the invite again, it will undismiss the progress so they have some feedback