### PR TITLE
Display Comments Count Next to Likes Count

### DIFF
--- a/App/Components/like-and-comment.tsx
+++ b/App/Components/like-and-comment.tsx
@@ -28,13 +28,17 @@ export interface Props {
   likesAndCommentsContainerStyle?: ViewStyle
   hasLiked: boolean
   numberLikes: number
+  numberComments: number
   onLike: () => void
   onComment: () => void
 }
 
 const LikeAndComment = (props: Props) => {
-  const { likesAndCommentsContainerStyle, hasLiked, numberLikes, onLike, onComment } = props
+  const { likesAndCommentsContainerStyle, hasLiked, numberLikes, numberComments, onLike, onComment } = props
   const likesWord = numberLikes === 0 || numberLikes > 1 ? 'likes' : 'like'
+  const commentsWord = numberComments === 0 || numberComments > 1 ? 'comments' : 'comment'
+  const displayLikesCount = ((!hasLiked && numberLikes > 0) || (hasLiked && numberLikes > 1))
+  const displayCommentsCount = (numberComments > 0)
   return (
     <View style={[CONTAINER, likesAndCommentsContainerStyle]}>
       <View style={ICONS}>
@@ -50,8 +54,8 @@ const LikeAndComment = (props: Props) => {
           <Icon name='comment' size={24} style={ICON} />
         </TouchableOpacity>
       </View>
-      {((!hasLiked && numberLikes > 0) || (hasLiked && numberLikes > 1)) &&
-        <Text style={TEXT}>{`${numberLikes} ${likesWord}`}</Text>
+      {displayLikesCount || displayCommentsCount &&
+        <Text style={TEXT}>{displayCommentsCount && `${numberComments} ${commentsWord}`}{displayLikesCount && displayCommentsCount && ` | `}{displayLikesCount && `${numberLikes} ${likesWord}`}</Text>
       }
     </View>
 

--- a/App/Containers/PhotoScreen.tsx
+++ b/App/Containers/PhotoScreen.tsx
@@ -96,6 +96,7 @@ class PhotoScreen extends React.Component<Props> {
           photoWidth={screenWidth}
           hasLiked={hasLiked}
           numberLikes={likes.length}
+          numberComments={comments.length}
           onLike={this.onAddLike}
           onComment={this.onComment}
           comments={commentsData}

--- a/App/screens/group/group.tsx
+++ b/App/screens/group/group.tsx
@@ -184,6 +184,7 @@ class Group extends React.PureComponent<Props, State> {
             photoWidth={screenWidth}
             hasLiked={hasLiked}
             numberLikes={likes.length}
+            numberComments={comments.length}
             onLike={this.onLike(block)}
             onComment={this.onComment(target)}
             comments={commentsData}


### PR DESCRIPTION
Fixes #1082. Display the comments count next to the likes count beneath photos in groups.