### PR TITLE
Process photos using a queue and workers

### DIFF
--- a/App/features/photos/actions.ts
+++ b/App/features/photos/actions.ts
@@ -12,6 +12,10 @@ export const updateLastQueriedTime = createAction('photos/UPDATE_LAST_QUERIED_TI
   return (epochSeconds: number) => resolve({ epochSeconds })
 })
 
+export const photoProcessingBegan = createAction('photo/PHOTO_PROCESSING_BEGAN', (resolve) => {
+  return (id: string) => resolve({ id })
+})
+
 export const photoPrepared = createAction('photos/PHOTO_PREPARED', (resolve) => {
   return (id: string, preparedFiles: IMobilePreparedFiles) => resolve({ id, preparedFiles })
 })

--- a/App/features/photos/models.ts
+++ b/App/features/photos/models.ts
@@ -3,7 +3,7 @@ import { IMobilePreparedFiles, IFiles } from '@textile/react-native-sdk'
 
 export interface ProcessingPhoto {
   readonly photo: LocalPhotoResult
-  readonly state: 'preparing' | 'adding' | 'complete'
+  readonly state: 'pending' | 'preparing' | 'adding' | 'complete'
   readonly preparedFiles?: IMobilePreparedFiles
   readonly error?: string
 }

--- a/App/features/photos/reducer.ts
+++ b/App/features/photos/reducer.ts
@@ -46,8 +46,14 @@ export default combineReducers<PhotosState, PhotosAction>({
     switch (action.type) {
       case getType(actions.queryCameraRoll.success): {
         return action.payload
-          .map((photo): ProcessingPhoto => ({ photo, state: 'preparing' }))
+          .map((photo): ProcessingPhoto => ({ photo, state: 'pending' }))
           .reduce((accum, processingPhoto): ProcessingPhotos => ({ ...accum, [processingPhoto.photo.assetId]: processingPhoto }), state)
+      }
+      case getType(actions.photoProcessingBegan): {
+        const { id } = action.payload
+        const processingPhoto = state[id]
+        const updated: ProcessingPhoto = { ...processingPhoto, state: 'preparing' }
+        return { ...state, [id]: updated }
       }
       case getType(actions.photoPrepared): {
         const { id, preparedFiles } = action.payload

--- a/App/features/photos/sagas.ts
+++ b/App/features/photos/sagas.ts
@@ -1,4 +1,5 @@
-import { all, take, select, call, put, fork, takeEvery } from 'redux-saga/effects'
+import { buffers, channel, Channel } from 'redux-saga'
+import { all, take, select, call, put, fork, takeEvery, cancelled } from 'redux-saga/effects'
 import { getType, ActionType } from 'typesafe-actions'
 import { requestLocalPhotos, LocalPhotoResult } from '@textile/react-native-camera-roll'
 import Textile, { IThread, IMobilePreparedFiles, IFilesList } from '@textile/react-native-sdk'
@@ -6,7 +7,7 @@ import Config from 'react-native-config'
 import FS from 'react-native-fs'
 
 import PreferencesActions, { PreferencesSelectors, Service } from '../../Redux/PreferencesRedux'
-import TextileEventsActions from '../../Redux/TextileEventsRedux'
+import TextileEventsActions, { TextileEventsSelectors } from '../../Redux/TextileEventsRedux'
 import * as actions from './actions'
 import * as selectors from './selectors'
 import { RootState } from '../../Redux/Types'
@@ -22,8 +23,32 @@ function * toggleStorage(action: ActionType<typeof PreferencesActions.toggleStor
   }
 }
 
-function * nodeOnline() {
-  while (yield take([getType(TextileEventsActions.nodeOnline), getType(TextileEventsActions.stopNodeAfterDelayCancelled)])) {
+function * bootstrapPhotoProcessing() {
+  const QUEUE_CONCURRENT = 1
+  const { watcher, addTaskChannel } = yield createQueue(photoHandler, QUEUE_CONCURRENT)
+  yield fork(watcher)
+  yield call(processPending, addTaskChannel)
+  yield fork(queryForNewPhotos, addTaskChannel)
+}
+
+function * photoHandler(payload: { id: string }) {
+  const { id } = payload
+  const online = yield select(TextileEventsSelectors.online)
+  if (!online) {
+    yield take(getType(TextileEventsActions.nodeOnline))
+  }
+  try {
+    yield put(actions.photoProcessingBegan(id))
+    yield call(preparePhoto, id)
+    yield call(addPhoto, id)
+    yield call(cleanup, id)
+  } catch (error) {
+    yield put(actions.photoProcessingError(id, error))
+  }
+}
+
+function * nodeStarted() {
+  while (yield take([getType(TextileEventsActions.nodeStarted), getType(TextileEventsActions.stopNodeAfterDelayCancelled)])) {
     const autoPinService: Service = yield select(PreferencesSelectors.storage, 'autoPinPhotos')
     if (autoPinService.status) {
       yield put(actions.queryCameraRoll.request())
@@ -31,7 +56,16 @@ function * nodeOnline() {
   }
 }
 
-function * queryForNewPhotos() {
+function * processPending(addTaskChannel: any) {
+  const pendingPhotos: ProcessingPhoto[] = yield select((state: RootState) => selectors.pendingPhotos(state.photos))
+  yield all(
+    pendingPhotos.map((photo) =>
+      put(addTaskChannel, { payload: { id: photo.photo.assetId } })
+    )
+  )
+}
+
+function * queryForNewPhotos(addTaskChannel: Channel<{}>) {
   while (yield take(getType(actions.queryCameraRoll.request))) {
     try {
       const lastRefresh: number | undefined = yield select((state: RootState) => selectors.lastQueriedTime(state.photos))
@@ -41,9 +75,11 @@ function * queryForNewPhotos() {
       const results: LocalPhotoResult[] = yield call(requestLocalPhotos, since)
       yield put(actions.queryCameraRoll.success(results))
       yield put(actions.updateLastQueriedTime(currentRefresh))
-      for (const localPhotoResult of results) {
-        yield fork(preparePhoto, localPhotoResult.assetId)
-      }
+      yield all(
+        results.map((result) =>
+          put(addTaskChannel, { payload: { id: result.assetId } })
+        )
+      )
     } catch (error) {
       yield put(actions.queryCameraRoll.failure(error))
     }
@@ -51,38 +87,28 @@ function * queryForNewPhotos() {
 }
 
 function * preparePhoto(id: string) {
-  try {
-    const selector = selectors.makeProcessingPhoto(id)
-    const processingPhoto: ProcessingPhoto = yield select((state: RootState) => selector(state.photos))
-    const thread: IThread | undefined = yield call(getCameraRollThread)
-    if (!thread) {
-      throw new Error('no camera roll thread found')
-    }
-    const preparedFiles: IMobilePreparedFiles = yield call(Textile.files.prepareByPath, processingPhoto.photo.path, thread.id)
-    yield put(actions.photoPrepared(id, preparedFiles))
-    yield call(addPhoto, id)
-  } catch (error) {
-    yield put(actions.photoProcessingError(id, error))
+  const selector = selectors.makeProcessingPhoto(id)
+  const processingPhoto: ProcessingPhoto = yield select((state: RootState) => selector(state.photos))
+  const thread: IThread | undefined = yield call(getCameraRollThread)
+  if (!thread) {
+    throw new Error('no camera roll thread found')
   }
+  const preparedFiles: IMobilePreparedFiles = yield call(Textile.files.prepareByPath, processingPhoto.photo.path, thread.id)
+  yield put(actions.photoPrepared(id, preparedFiles))
 }
 
 function * addPhoto(id: string) {
-  try {
-    const selector = selectors.makeProcessingPhoto(id)
-    const processingPhoto: ProcessingPhoto = yield select((state: RootState) => selector(state.photos))
-    const thread: IThread | undefined = yield call(getCameraRollThread)
-    if (!thread) {
-      throw new Error('no camera roll thread found')
-    }
-    if (!processingPhoto.preparedFiles) {
-      throw new Error('no prepared files found')
-    }
-    yield call(Textile.files.add, processingPhoto.preparedFiles.dir, thread.id)
-    yield put(actions.photoAdded(id))
-    yield call(cleanup, id)
-  } catch (error) {
-    yield put(actions.photoProcessingError(id, error))
+  const selector = selectors.makeProcessingPhoto(id)
+  const processingPhoto: ProcessingPhoto = yield select((state: RootState) => selector(state.photos))
+  const thread: IThread | undefined = yield call(getCameraRollThread)
+  if (!thread) {
+    throw new Error('no camera roll thread found')
   }
+  if (!processingPhoto.preparedFiles) {
+    throw new Error('no prepared files found')
+  }
+  yield call(Textile.files.add, processingPhoto.preparedFiles.dir, thread.id)
+  yield put(actions.photoAdded(id))
 }
 
 function * cleanup(id: string) {
@@ -136,11 +162,45 @@ function * watchForLoadPhotosRequests() {
   }
 }
 
+function* createQueue(handle: (...args: any[]) => IterableIterator<any>, concurrent = 1) {
+  const addTaskChannel: Channel<{}> = yield call(channel, buffers.expanding())
+  // create a channel to queue incoming requests
+  const runChannel: Channel<{}> = yield call(channel, buffers.expanding())
+  function* watchRequests() {
+    try {
+      // create n worker 'threads'
+      yield all(Array(concurrent).fill(fork(handleRequest, runChannel)))
+
+      while (true) {
+        const { payload } = yield take(addTaskChannel)
+        yield put(runChannel, payload)
+      }
+    } finally {
+      if (yield cancelled()) {
+        addTaskChannel.close()
+        runChannel.close()
+      }
+    }
+  }
+
+  function* handleRequest(chan: Channel<{}>) {
+    while (true) {
+      const payload = yield take(chan)
+      yield handle(payload)
+    }
+  }
+
+  return {
+    watcher: watchRequests,
+    addTaskChannel
+  }
+}
+
 export default function *() {
   yield all([
     takeEvery(getType(PreferencesActions.toggleStorageRequest), toggleStorage),
-    call(nodeOnline),
-    call(queryForNewPhotos),
+    call(nodeStarted),
+    call(bootstrapPhotoProcessing),
     call(watchForLoadPhotosRequests)
   ])
 }

--- a/App/features/photos/sagas.ts
+++ b/App/features/photos/sagas.ts
@@ -56,7 +56,7 @@ function * nodeStarted() {
   }
 }
 
-function * processPending(addTaskChannel: any) {
+function * processPending(addTaskChannel: Channel<{}>) {
   const pendingPhotos: ProcessingPhoto[] = yield select((state: RootState) => selectors.pendingPhotos(state.photos))
   yield all(
     pendingPhotos.map((photo) =>

--- a/App/features/photos/selectors.ts
+++ b/App/features/photos/selectors.ts
@@ -4,6 +4,11 @@ import Textile from '@textile/react-native-sdk'
 
 export const lastQueriedTime = (state: PhotosState) => state.queryData.lastQueriedTime
 
+export const pendingPhotos = (state: PhotosState) =>
+  Object.keys(state.processingPhotos)
+    .map((key) => state.processingPhotos[key])
+    .filter((photo) => photo.state === 'pending')
+
 export const makeProcessingPhoto = (id: string) => (state: PhotosState) => state.processingPhotos[id]
 
 export const items = (state: PhotosState) => {

--- a/App/screens/photos.tsx
+++ b/App/screens/photos.tsx
@@ -113,7 +113,8 @@ class Photos extends Component<Props> {
         />
       )
     } else {
-      const { photo, error } = row.item.processingPhoto
+      const { photo, state, error } = row.item.processingPhoto
+      const color = state === 'pending' ? 'white' : 'blue'
       const uri = `file://${photo.path}`
       return (
         <View style={{ width: itemSize, height: itemSize }}>
@@ -128,7 +129,7 @@ class Photos extends Component<Props> {
             </TouchableOpacity>
           }
           {!error &&
-            <View style={{ width: 12, height: 12, backgroundColor: 'white', borderColor: 'black', borderWidth: 1, borderRadius: 6, position: 'absolute', right: 5, bottom: 5 }} />
+            <View style={{ width: 12, height: 12, backgroundColor: color, borderColor: 'black', borderWidth: 1, borderRadius: 6, position: 'absolute', right: 5, bottom: 5 }} />
           }
         </View>
       )


### PR DESCRIPTION
We want some control over how concurrency is used to process camera roll photos, adding them to the local Textile node. This allows us to balance speed and memory consumption. 

Closes #1073