### PR TITLE
Display loading component while loading persisted data

### DIFF
--- a/App/Components/Loading.tsx
+++ b/App/Components/Loading.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { View, ActivityIndicator, ActivityIndicatorProps } from 'react-native'
+
+import { color } from '../styles'
+
+interface Props extends ActivityIndicatorProps {
+  backgroundColor?: string
+}
+
+const loading = (props: Props) => {
+  const backgroundColor = props.backgroundColor ? props.backgroundColor : color.screen_primary
+  const indicatorProps: ActivityIndicatorProps = { size: 'large', ...props }
+  return (
+    <View style={{ flex: 1, alignContent: 'center', justifyContent: 'center', backgroundColor }}>
+      <ActivityIndicator {...indicatorProps} />
+    </View>
+  )
+}
+
+export default loading

--- a/App/Containers/App.tsx
+++ b/App/Containers/App.tsx
@@ -2,7 +2,10 @@ import '../Config'
 import React, { Component } from 'react'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
+import Textile from '@textile/react-native-sdk'
+
 import RootContainer from './RootContainer'
+import Loading from '../Components/Loading'
 import configureStore from '../Redux/configureStore'
 import TextileNodeEventHandler from '../Services/EventHandlers/TextileNodeEventHandler'
 import UploadEventHandler from '../Services/EventHandlers/UploadEventHandler'
@@ -10,8 +13,7 @@ import DeepLinkEventHandler from '../Services/EventHandlers/DeepLinkEventHandler
 import BackgroundFetchEventHandler from '../Services/EventHandlers/BackgroundFetchEventHandler'
 import NotificationEventHandler from '../Services/EventHandlers/NotificationEventHandler'
 import { errorHandler } from '../Services/ErrorHandler'
-
-import Textile from '@textile/react-native-sdk'
+import { color } from '../styles'
 
 const { store, persistor } = configureStore()
 
@@ -27,7 +29,7 @@ class App extends Component {
   render() {
     return (
       <Provider store={store}>
-        <PersistGate loading={undefined} persistor={persistor}>
+        <PersistGate loading={<Loading color={color.brandRed} />} persistor={persistor}>
           <RootContainer />
         </PersistGate>
       </Provider>

--- a/App/Containers/StatusCheck.tsx
+++ b/App/Containers/StatusCheck.tsx
@@ -3,10 +3,12 @@ import { ActivityIndicator, View } from 'react-native'
 import { connect } from 'react-redux'
 import { NavigationScreenProps } from 'react-navigation'
 
+import Loading from '../Components/Loading'
 import FatalErrorView from '../Components/FatalErrorView'
 
 import { RootState } from '../Redux/Types'
 import { TextileEventsSelectors } from '../Redux/TextileEventsRedux'
+import { color } from '../styles'
 
 interface StateProps {
   onboarded: boolean
@@ -40,9 +42,7 @@ class StatusCheck extends React.Component<Props, {}> {
       )
     } else {
       return (
-        <View style={{ flex: 1, alignContent: 'center', justifyContent: 'center' }}>
-          <ActivityIndicator size='large' />
-        </View>
+        <Loading color={color.brandBlue} />
       )
     }
   }


### PR DESCRIPTION
We were previously not instructing redux-persist to display any view while loading the persisted data. This PR tells redux-persist to display our `Loading` component with a red spinner while it's loading the persisted data.

I also updates the `StatusCheck` screen (which blocks any UI from rendering until the node is started) to display a blue spinner.

The idea is we can know, while the spinners are displaying during app startup, which is taking a long time. 