### PR TITLE
File sharing to iTunes

### DIFF
--- a/ios/Textile/Info.plist
+++ b/ios/Textile/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>NSContactsUsageDescription</key>
 	<string>Authorizing access to your contacts makes it easy for you to invite others to Textile. None of you contact data is saved or transmitted in any way.</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ios/Textile/Info.plist
+++ b/ios/Textile/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIFileSharingEnabled</key>
-	<true/>
 	<key>NSContactsUsageDescription</key>
 	<string>Authorizing access to your contacts makes it easy for you to invite others to Textile. None of you contact data is saved or transmitted in any way.</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -37,6 +37,7 @@ platform :ios do
       "-UseModernBuildSystem" => "NO"
     }
     match(type: "adhoc")
+    set_info_plist_value(path: "./Textile/Info.plist", key: "UIFileSharingEnabled", value: true)
     increment_build_number(
       build_number: ENV['CIRCLE_BUILD_NUM'],
       xcodeproj: "Textile.xcodeproj"

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -37,7 +37,6 @@ platform :ios do
       "-UseModernBuildSystem" => "NO"
     }
     match(type: "adhoc")
-    set_info_plist_value(path: "./Textile/Info.plist", key: "UIFileSharingEnabled", value: true)
     increment_build_number(
       build_number: ENV['CIRCLE_BUILD_NUM'],
       xcodeproj: "Textile.xcodeproj"
@@ -102,6 +101,7 @@ platform :ios do
       "-UseModernBuildSystem" => "NO"
     }
     match(type: "appstore") # more information: https://codesigning.guide
+    set_info_plist_value(path: "./Textile/Info.plist", key: "UIFileSharingEnabled", value: false)
     tag = ENV['CIRCLE_TAG'] # looks like ios_1.2.3_456
     parts = tag.split("_")
     increment_version_number(


### PR DESCRIPTION
Decision was to make file sharing enabled by default so that all dev and beta builds have it, but then to disable it during the release build.

Should make it easier to grab repo data for any dev or beta build.