### PR TITLE
Try allowing default build system

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -33,8 +33,7 @@ platform :ios do
     APP_ID = "io.textile.Wallet.beta"
     PROFILE = "match AdHoc io.textile.Wallet.beta"
     settings_to_override = {
-      :PROVISIONING_PROFILE_SPECIFIER => PROFILE,
-      "-UseModernBuildSystem" => "NO"
+      :PROVISIONING_PROFILE_SPECIFIER => PROFILE
     }
     match(type: "adhoc")
     increment_build_number(
@@ -97,8 +96,7 @@ platform :ios do
     APP_ID = "io.textile.Wallet"
     PROFILE = "match AppStore io.textile.Wallet"
     settings_to_override = {
-      :PROVISIONING_PROFILE_SPECIFIER => PROFILE,
-      "-UseModernBuildSystem" => "NO"
+      :PROVISIONING_PROFILE_SPECIFIER => PROFILE
     }
     match(type: "appstore") # more information: https://codesigning.guide
     set_info_plist_value(path: "./Textile/Info.plist", key: "UIFileSharingEnabled", value: false)


### PR DESCRIPTION
At one point with older RN we needed to disable the new build system, but hopefully that's fixed now. Hoping this helps with these random CI failures that happen too often