### PR TITLE
Trigger permissions when toggling on auto pin

### DIFF
--- a/App/Sagas/TextileSagas.ts
+++ b/App/Sagas/TextileSagas.ts
@@ -13,7 +13,9 @@ import { Share, PermissionsAndroid, Platform } from 'react-native'
 import { call, put, select } from 'redux-saga/effects'
 import RNFS from 'react-native-fs'
 import Config from 'react-native-config'
-import Textile, { IThread } from '@textile/react-native-sdk'
+import Textile from '@textile/react-native-sdk'
+
+import { cameraPermissionsTrigger } from '../Services/CameraRoll'
 import NavigationService from '../Services/NavigationService'
 import * as NotificationsSagas from './NotificationsSagas'
 import UploadingImagesActions, {
@@ -25,7 +27,6 @@ import PreferencesActions, {
 } from '../Redux/PreferencesRedux'
 import UIActions, { UISelectors } from '../Redux/UIRedux'
 import { ActionType } from 'typesafe-actions'
-import * as CameraRoll from '../Services/CameraRoll'
 import Upload from 'react-native-background-upload'
 import PhotoViewingActions, { ThreadData } from '../Redux/PhotoViewingRedux'
 import { logNewEvent } from './DeviceLogs'
@@ -176,22 +177,8 @@ export function* updateServices(
   }
 }
 
-export function* cameraPermissionsTrigger() {
-  // Will trigger a camera permission request
-  if (Platform.OS === 'android') {
-    const permission = yield call(
-      PermissionsAndroid.request,
-      PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
-      {
-        title: 'Textile Photos Photos Permission',
-        message:
-          'Textile accesses your photo storage to import any new photos you take after you install the app.',
-        buttonPositive: 'Ok'
-      }
-    )
-  } else {
-    CameraRoll.getPhotos(1)
-  }
+export function* triggerCameraRollPermission() {
+  yield call(cameraPermissionsTrigger)
 }
 
 export function* addPhotoLike(

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -74,7 +74,7 @@ import {
   navigateToComments,
   navigateToLikes,
   addPhotoLike,
-  cameraPermissionsTrigger,
+  triggerCameraRollPermission,
   presentPublicLinkInterface,
   updateServices
 } from './TextileSagas'
@@ -105,7 +105,7 @@ export default function* root(dispatch: Dispatch) {
     // permissions request events
     takeLatest(
       getType(AuthActions.requestCameraPermissions),
-      cameraPermissionsTrigger
+      triggerCameraRollPermission
     ),
     takeLatest(
       getType(PreferencesActions.toggleServicesRequest),

--- a/App/Services/CameraRoll.ts
+++ b/App/Services/CameraRoll.ts
@@ -1,4 +1,4 @@
-import { CameraRoll, Platform } from 'react-native'
+import { CameraRoll, Platform, PermissionsAndroid } from 'react-native'
 import ImagePicker from 'react-native-image-picker'
 
 export interface IPickerImage {
@@ -144,4 +144,21 @@ export async function launchImageLibrary(): Promise<IPickerImage> {
       resolve(result)
     })
   })
+}
+
+export async function cameraPermissionsTrigger() {
+  // Will trigger a camera permission request
+  if (Platform.OS === 'android') {
+    return await PermissionsAndroid.request(
+      PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
+      {
+        title: 'Textile Photos Photos Permission',
+        message:
+          'Textile accesses your photo storage to import any new photos you take after you install the app.',
+        buttonPositive: 'Ok'
+      }
+    )
+  } else {
+    return await getPhotos(1)
+  }
 }

--- a/App/features/photos/sagas.ts
+++ b/App/features/photos/sagas.ts
@@ -22,6 +22,7 @@ import Textile, {
 import Config from 'react-native-config'
 import FS from 'react-native-fs'
 
+import { cameraPermissionsTrigger } from '../../Services/CameraRoll'
 import PreferencesActions, {
   PreferencesSelectors,
   Service
@@ -53,6 +54,7 @@ function* toggleStorage(
     // Always start autoPinning only from the date of the latest toggle-on
     const now = new Date().getTime()
     yield put(actions.updateLastQueriedTime(now))
+    yield call(cameraPermissionsTrigger)
   }
 }
 


### PR DESCRIPTION
There was a case where the app doesn't have permissions to access camera roll by the time you toggle on camera roll auto pin. This makes sure you're prompted for permission when toggling on auto pin if you haven't been previously. Also did a little DRY refactor for the actual permission triggering code since it's used from other places as well.