### PR TITLE
Fix node logs + extras

### DIFF
--- a/App/Components/NodeLogsScreen.tsx
+++ b/App/Components/NodeLogsScreen.tsx
@@ -63,7 +63,7 @@ export default class NodeLogsScreen extends Component<
   refreshLogData = async () => {
     this.setState({ refreshing: true, logData: undefined, error: undefined })
     try {
-      const repoPath = await Textile.repoPath
+      const repoPath = await Textile.repoPath()
       const logFilePath = `${repoPath}/logs/textile.log`
       const exists = await FS.exists(logFilePath)
       if (exists) {

--- a/App/Sagas/TextileEventsSagas.ts
+++ b/App/Sagas/TextileEventsSagas.ts
@@ -27,10 +27,11 @@ function displayNotification(message: string, title?: string) {
 
 function* initializeTextile() {
   try {
+    const verbose = yield select(PreferencesSelectors.verboseUi)
     const phrase: string | undefined = yield call(
       Textile.initialize,
-      false,
-      false
+      verbose,
+      true
     )
     if (phrase) {
       yield put(accountActions.setRecoveryPhrase(phrase))

--- a/App/Sagas/TextileSagas.ts
+++ b/App/Sagas/TextileSagas.ts
@@ -13,7 +13,7 @@ import { Share, PermissionsAndroid, Platform } from 'react-native'
 import { call, put, select } from 'redux-saga/effects'
 import RNFS from 'react-native-fs'
 import Config from 'react-native-config'
-import Textile from '@textile/react-native-sdk'
+import Textile, { ILogLevel, LogLevel } from '@textile/react-native-sdk'
 
 import { cameraPermissionsTrigger } from '../Services/CameraRoll'
 import NavigationService from '../Services/NavigationService'
@@ -158,6 +158,29 @@ export function* backgroundLocationPermissionsTrigger() {
     )
   } else {
     yield call(navigator.geolocation.requestAuthorization)
+  }
+}
+
+export function* handleToggleVerboseUi(
+  action: ActionType<typeof PreferencesActions.toggleVerboseUi>
+) {
+  try {
+    const verbose: boolean = yield select(PreferencesSelectors.verboseUi)
+    const level = verbose ? LogLevel.Level.DEBUG : LogLevel.Level.ERROR
+    const logLevel: ILogLevel = {
+      systems: {
+        'tex-broadcast': level,
+        'tex-core': level,
+        'tex-datastore': level,
+        'tex-ipfs': level,
+        'tex-mill': level,
+        'tex-repo': level,
+        'tex-service': level
+      }
+    }
+    yield call(Textile.logs.setLevel, logLevel)
+  } catch (error) {
+    // @todo: nothing for now
   }
 }
 

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -76,7 +76,8 @@ import {
   addPhotoLike,
   triggerCameraRollPermission,
   presentPublicLinkInterface,
-  updateServices
+  updateServices,
+  handleToggleVerboseUi
 } from './TextileSagas'
 
 import { startSagas } from './TextileEventsSagas'
@@ -110,6 +111,12 @@ export default function* root(dispatch: Dispatch) {
     takeLatest(
       getType(PreferencesActions.toggleServicesRequest),
       updateServices
+    ),
+
+    // verbose ui
+    takeEvery(
+      getType(PreferencesActions.toggleVerboseUi),
+      handleToggleVerboseUi
     ),
 
     takeEvery(getType(UIActions.navigateToThreadRequest), navigateToThread),

--- a/App/features/account/sagas.ts
+++ b/App/features/account/sagas.ts
@@ -38,7 +38,9 @@ async function registerCafes() {
     }
     const cafes = await lbApi(lbUrl).discoveredCafes()
     if (!cafes.primary && !cafes.secondary) {
-      throw new Error('discovered cafes response does not not include any cafes')
+      throw new Error(
+        'discovered cafes response does not not include any cafes'
+      )
     }
     cafeUrl = cafes.primary ? cafes.primary.url : cafes.secondary!.url
   }


### PR DESCRIPTION
**IMPORTANT:** This will require a delete and reinstall of the Beta app to allow the node logs to work again (they previously weren't being written to disk, and the only time that is configured is during node initialization which only happens one time, the first time the app runs).

* Write textile logs to disk
* Fix bug that would have prevented log file from being found
* Increases the log level to `DEBUG` when verbose UI is on, `ERROR` level otherwise

Fixes #1119 