### PR TITLE
uses a flatlist instead of scrollview-textarea for android log

### DIFF
--- a/App/Components/NodeLogsScreen.tsx
+++ b/App/Components/NodeLogsScreen.tsx
@@ -6,13 +6,16 @@ import {
   Clipboard,
   ActivityIndicator,
   View,
-  Text
+  Text,
+  ListRenderItemInfo,
+  Animated
 } from 'react-native'
 import FS from 'react-native-fs'
 import { NavigationScreenProps } from 'react-navigation'
 import Textile from '@textile/react-native-sdk'
 import { TextileHeaderButtons, Item as TextileItem } from './HeaderButtons'
 import { color, fontSize, spacing } from '../styles'
+import { FlatList, TouchableOpacity } from 'react-native-gesture-handler'
 
 interface NavProps {
   refresh: () => void
@@ -21,7 +24,10 @@ interface NavProps {
 
 interface State {
   refreshing: boolean
+  logRows: string[]
+  fadeOut: Animated.Value
   logData?: string
+  selectStart?: number
   error?: string
 }
 
@@ -55,13 +61,22 @@ export default class NodeLogsScreen extends Component<
     }
   }
 
-  state: State = { refreshing: false }
+  state: State = {
+    refreshing: false,
+    logRows: [],
+    fadeOut: new Animated.Value(0)
+  }
 
   textInput?: TextInput
   scrollView?: ScrollView
 
   refreshLogData = async () => {
-    this.setState({ refreshing: true, logData: undefined, error: undefined })
+    this.setState({
+      refreshing: true,
+      logData: undefined,
+      logRows: [],
+      error: undefined
+    })
     try {
       const repoPath = await Textile.repoPath()
       const logFilePath = `${repoPath}/logs/textile.log`
@@ -72,7 +87,11 @@ export default class NodeLogsScreen extends Component<
         const bytesToRead = 1024 * 300 // 300KB
         const offset = Math.max(size, bytesToRead) - bytesToRead
         const contents = await FS.read(logFilePath, bytesToRead, offset, 'utf8')
-        this.setState({ logData: contents, error: undefined })
+        this.setState({
+          logRows: contents.split('\n').reverse(),
+          logData: contents,
+          error: undefined
+        })
       }
     } catch (error) {
       const message =
@@ -83,9 +102,21 @@ export default class NodeLogsScreen extends Component<
     }
   }
 
+  // Rarely can the phone handle copy of full logs to clipboard and paste elsewhere, so limiting to 100 rows here
   copyLogData = () => {
     if (this.state.logData) {
-      Clipboard.setString(this.state.logData)
+      Clipboard.setString(
+        this.state.logRows
+          .slice(Math.max(this.state.logRows.length - 100, 0))
+          .join('\n')
+      )
+    }
+  }
+
+  copyRow = (text: string) => {
+    return () => {
+      Clipboard.setString(text)
+      this.copyNotify()
     }
   }
 
@@ -102,9 +133,106 @@ export default class NodeLogsScreen extends Component<
     })
     this.refreshLogData()
   }
+  copyNotify() {
+    this.state.fadeOut.setValue(0.7)
+    Animated.timing(this.state.fadeOut, {
+      toValue: 0,
+      duration: 2000
+    }).start()
+  }
+  renderLogEntry = (row: ListRenderItemInfo<any>) => {
+    const { item } = row
+    const font = Platform.OS === 'ios' ? 'Courier' : 'monospace'
+    return (
+      <TouchableOpacity onPress={this.copyRow(item)} activeOpacity={0.75}>
+        <Text
+          style={{
+            fontFamily: font,
+            fontSize: fontSize._12,
+            color: 'black'
+          }}
+        >
+          {item}
+        </Text>
+      </TouchableOpacity>
+    )
+  }
+
+  renderFlatList = () => {
+    return (
+      <View
+        style={{
+          flex: 1
+        }}
+      >
+        <FlatList
+          inverted={true}
+          data={this.state.logRows}
+          renderItem={this.renderLogEntry}
+          style={{
+            flex: 1,
+            paddingHorizontal: spacing.screenEdge,
+            backgroundColor: color.screen_primary
+          }}
+        />
+        <Animated.View
+          style={{
+            opacity: this.state.fadeOut,
+            position: 'absolute',
+            bottom: 0,
+            width: '100%'
+          }}
+        >
+          <View
+            style={{
+              backgroundColor: color.screen_primary,
+              paddingVertical: 8
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 20,
+                textAlign: 'center',
+                color: 'black'
+              }}
+            >
+              copied
+            </Text>
+          </View>
+        </Animated.View>
+      </View>
+    )
+  }
+
+  renderScrollView = () => {
+    return (
+      <ScrollView
+        ref={ref => {
+          this.scrollView = ref ? ref : undefined
+        }}
+        style={{ flex: 1, backgroundColor: color.screen_primary }}
+      >
+        <TextInput
+          ref={ref => {
+            this.textInput = ref ? ref : undefined
+          }}
+          style={{
+            flex: 1,
+            fontFamily: 'Courier',
+            fontSize: fontSize._12,
+            paddingHorizontal: spacing.screenEdge,
+            backgroundColor: color.screen_primary
+          }}
+          editable={false}
+          value={this.state.logData}
+          multiline={true}
+          onContentSizeChange={this.scrollToBottom}
+        />
+      </ScrollView>
+    )
+  }
 
   render() {
-    const font = Platform.OS === 'ios' ? 'Courier' : 'monospace'
     if (this.state.error && this.state.error !== '') {
       return (
         <View
@@ -132,31 +260,10 @@ export default class NodeLogsScreen extends Component<
         </View>
       )
     } else {
-      return (
-        <ScrollView
-          ref={ref => {
-            this.scrollView = ref ? ref : undefined
-          }}
-          style={{ flex: 1, backgroundColor: color.screen_primary }}
-        >
-          <TextInput
-            ref={ref => {
-              this.textInput = ref ? ref : undefined
-            }}
-            style={{
-              flex: 1,
-              fontFamily: font,
-              fontSize: fontSize._12,
-              paddingHorizontal: spacing.screenEdge,
-              backgroundColor: color.screen_primary
-            }}
-            editable={false}
-            value={this.state.logData}
-            multiline={true}
-            onContentSizeChange={this.scrollToBottom}
-          />
-        </ScrollView>
-      )
+      if (Platform.OS === 'ios') {
+        return this.renderScrollView()
+      }
+      return this.renderFlatList()
     }
   }
 }


### PR DESCRIPTION
scrollview approach works well on iOS so i didn't want to remove it. at the same time, it doesn't work on android because of reason linked here, https://github.com/textileio/photos/issues/1136. so for android it uses a flatlist and allows row-based copy by touch.