### PR TITLE
Block root saga until redux is rehydrated

### DIFF
--- a/App/Redux/configureStore.ts
+++ b/App/Redux/configureStore.ts
@@ -28,7 +28,7 @@ export default () => {
   const bootstrappedCallback = () => store.dispatch(StartupActions.startup())
   const persistor = persistStore(store, undefined, bootstrappedCallback)
 
-  sagaMiddleware.run(rootSaga, store.dispatch)
+  sagaMiddleware.run(rootSaga)
 
   return { store, persistor }
 }


### PR DESCRIPTION
This was definitely causing a bug where the node was being started with a log level of `ERROR` even if the user has verbose UI on and it was supposed to be `DEBUG`. This is because we were reading the verbose UI redux state before the persisted preference data was merged into the state. The default value for verbose UI (before re-hydration) is `false`, therefore log level was set to `ERROR`.

This doesn't let any sagas run until re-hydration is complete.

I'm trying to think through other potential bugs this could have been causing, hard to say, but it could have definitely be causing some weirdness related to issues @andrewxhill has been seeing.