### PR TITLE
xcode 10.2.0 for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,7 @@ jobs:
 
   ios-release:
     macos:
-      xcode: '10.2.1'
+      xcode: '10.2.0'
     environment:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8


### PR DESCRIPTION
The CircleCI Xcode 10.2.1 image is missing some package (probably `watchman`) so building for distribution breaks because the js bundle isn't created. 