### PR TITLE
Fix asynchronous likes

### DIFF
--- a/App/Containers/PhotoScreen.tsx
+++ b/App/Containers/PhotoScreen.tsx
@@ -94,13 +94,13 @@ class PhotoScreen extends React.Component<Props> {
     const pinchWidth = !files.length
       ? def
       : !files[0].links.large
-        ? def
-        : files[0].links.large.meta.fields.width.numberValue
+      ? def
+      : files[0].links.large.meta.fields.width.numberValue
     const pinchHeight = !files.length
       ? def
       : !files[0].links.large
-        ? def
-        : files[0].links.large.meta.fields.height.numberValue
+      ? def
+      : files[0].links.large.meta.fields.height.numberValue
     const fileIndex =
       files && files.length > 0 && files[0].index ? files[0].index : 0
     return (
@@ -152,9 +152,12 @@ const mapStateToProps = (state: RootState): StateProps => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<RootAction>): DispatchProps => ({
-  addLike: (block: string) => dispatch(UIActions.addLike.request({
-    blockId: block
-  }))
+  addLike: (block: string) =>
+    dispatch(
+      UIActions.addLike.request({
+        blockId: block
+      })
+    )
 })
 
 export default connect(

--- a/App/Containers/PhotoScreen.tsx
+++ b/App/Containers/PhotoScreen.tsx
@@ -94,13 +94,13 @@ class PhotoScreen extends React.Component<Props> {
     const pinchWidth = !files.length
       ? def
       : !files[0].links.large
-      ? def
-      : files[0].links.large.meta.fields.width.numberValue
+        ? def
+        : files[0].links.large.meta.fields.width.numberValue
     const pinchHeight = !files.length
       ? def
       : !files[0].links.large
-      ? def
-      : files[0].links.large.meta.fields.height.numberValue
+        ? def
+        : files[0].links.large.meta.fields.height.numberValue
     const fileIndex =
       files && files.length > 0 && files[0].index ? files[0].index : 0
     return (
@@ -152,7 +152,9 @@ const mapStateToProps = (state: RootState): StateProps => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<RootAction>): DispatchProps => ({
-  addLike: (block: string) => dispatch(UIActions.addLikeRequest(block))
+  addLike: (block: string) => dispatch(UIActions.addLike.request({
+    blockId: block
+  }))
 })
 
 export default connect(

--- a/App/Redux/UIRedux.ts
+++ b/App/Redux/UIRedux.ts
@@ -71,9 +71,6 @@ const actions = {
     return (threadId: string, threadName: string) =>
       resolve({ threadId, threadName })
   }),
-  addLikeRequest: createAction('ADD_LIKE_REQUEST', resolve => {
-    return (blockId: string) => resolve({ blockId })
-  }),
   addLike: createAsyncAction(
     'ADD_LIKE_REQUEST',
     'ADD_LIKE_SUCCESS',
@@ -160,9 +157,10 @@ export function reducer(
         }
       }
     }
-    case getType(actions.addLike.success):
-    case getType(actions.addLike.failure): {
+    case getType(actions.addLike.failure):
+    case getType(actions.addLike.success): {
       const { likingPhotos } = state
+      const { blockId } = action.payload
       const {
         [action.payload.blockId]: liked,
         ...newLikingPhotos

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -106,7 +106,7 @@ function* waitForRehydrate() {
   }
 }
 
-export default function*() {
+export default function* () {
   yield call(waitForRehydrate)
   yield all([
     call(accountSaga),
@@ -145,7 +145,7 @@ export default function*() {
     takeEvery(getType(UIActions.navigateToThreadRequest), navigateToThread),
     takeEvery(getType(UIActions.navigateToCommentsRequest), navigateToComments),
     takeEvery(getType(UIActions.navigateToLikesRequest), navigateToLikes),
-    takeEvery(getType(UIActions.addLikeRequest), addPhotoLike),
+    takeEvery(getType(UIActions.addLike.request), addPhotoLike),
 
     takeEvery(getType(PhotoViewingActions.addThreadRequest), addThread),
     takeEvery(

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -106,7 +106,7 @@ function* waitForRehydrate() {
   }
 }
 
-export default function* () {
+export default function*() {
   yield call(waitForRehydrate)
   yield all([
     call(accountSaga),


### PR DESCRIPTION
Fixes #1143. Fixes #1159. The actions dispatched from `PhotoScreen.tsx` and watched for in the saga needed to be brought in line with the new `createAsyncAction` structure.