### PR TITLE
File sync group status screen

### DIFF
--- a/App/Navigation/AppNavigation/Modal/Settings/index.ts
+++ b/App/Navigation/AppNavigation/Modal/Settings/index.ts
@@ -7,6 +7,7 @@ import AccountSeed from '../../../../Containers/AccountSeed'
 import RegisterCafe from '../../../../Containers/RegisterCafe'
 import Cafe from '../../../../Containers/Cafe'
 import Storage from '../../../../SB/views/Storage'
+import FileSync from '../../../../screens/file-sync'
 import DeviceLogs from '../../../../SB/views/DeviceLogs'
 import NodeLogsScreen from '../../../../Components/NodeLogsScreen'
 import RecoveryPhrase from '../../../../SB/views/UserProfile/RecoveryPhrase'
@@ -23,6 +24,7 @@ const nav = createStackNavigator(
     RegisterCafe,
     Cafe,
     Storage,
+    FileSync,
     RecoveryPhrase,
     ChangeAvatar: SetAvatar,
     DeviceLogs,

--- a/App/SB/views/UserProfile/index.tsx
+++ b/App/SB/views/UserProfile/index.tsx
@@ -84,6 +84,10 @@ class UserProfile extends React.PureComponent<Props> {
     this.props.navigation.navigate('Storage')
   }
 
+  _fileSync = () => {
+    this.props.navigation.navigate('FileSync')
+  }
+
   _deviceLogs = () => {
     this.props.navigation.navigate('DeviceLogs')
   }
@@ -191,6 +195,11 @@ class UserProfile extends React.PureComponent<Props> {
           {this.props.verboseUi && (
             <TouchableOpacity style={styles.listItem} onPress={this._storage}>
               <Text style={styles.listText}>Storage</Text>
+            </TouchableOpacity>
+          )}
+          {this.props.verboseUi && (
+            <TouchableOpacity style={styles.listItem} onPress={this._fileSync}>
+              <Text style={styles.listText}>File Sync</Text>
             </TouchableOpacity>
           )}
           {this.props.verboseUi && (

--- a/App/features/group/file-sync/models.ts
+++ b/App/features/group/file-sync/models.ts
@@ -1,4 +1,5 @@
 export interface GroupStatus {
+  groupId: string
   numberComplete: number
   numberTotal: number
   sizeComplete: number

--- a/App/features/group/file-sync/reducer.ts
+++ b/App/features/group/file-sync/reducer.ts
@@ -26,7 +26,13 @@ export default combineReducers<FileSyncState, FileSyncAction>({
         } = action.payload
         return {
           ...state,
-          [groupId]: { numberComplete, numberTotal, sizeComplete, sizeTotal }
+          [groupId]: {
+            groupId,
+            numberComplete,
+            numberTotal,
+            sizeComplete,
+            sizeTotal
+          }
         }
       }
       case getType(actions.syncFailed): {

--- a/App/features/group/file-sync/selectors.ts
+++ b/App/features/group/file-sync/selectors.ts
@@ -7,3 +7,7 @@ export const makeStatusForId = (id: string) => (state: FileSyncState) => {
     return undefined
   }
 }
+
+export const groupStatuses = (state: FileSyncState) => {
+  return Object.keys(state.groups).map(key => state.groups[key])
+}

--- a/App/screens/file-sync.tsx
+++ b/App/screens/file-sync.tsx
@@ -1,0 +1,131 @@
+import React, { Component } from 'react'
+import {
+  View,
+  FlatList,
+  ListRenderItemInfo,
+  TouchableOpacity
+} from 'react-native'
+import { Dispatch } from 'redux'
+import { connect } from 'react-redux'
+import { NavigationScreenProps } from 'react-navigation'
+import Icon from '@textile/react-native-icon'
+import Toast from 'react-native-easy-toast'
+
+import { groupSelectors, groupActions } from '../features/group'
+import { Item, TextileHeaderButtons } from '../Components/HeaderButtons'
+import ListItem from '../Components/ListItem'
+import RowSeparator from '../Components/RowSeparator'
+import { RootState, RootAction } from '../Redux/Types'
+import { GroupStatus } from '../features/group/file-sync/models'
+import { color, size } from '../styles'
+
+interface StateProps {
+  readonly groupStatuses: ReadonlyArray<GroupStatus>
+}
+
+interface DispatchProps {
+  readonly clearGroupStatus: (groupId: string) => void
+}
+
+type Props = StateProps & DispatchProps & NavigationScreenProps
+
+class FileSync extends Component<Props> {
+  static navigationOptions = ({ navigation }: NavigationScreenProps) => {
+    const goBack = () => navigation.goBack()
+    const headerLeft = (
+      <TextileHeaderButtons left={true}>
+        <Item title="Back" onPress={goBack} iconName="arrow-left" />
+      </TextileHeaderButtons>
+    )
+    return {
+      headerLeft,
+      headerTitle: 'Active Sync Groups'
+    }
+  }
+
+  toast?: Toast
+
+  showError = (message: string) => () => {
+    if (this.toast) {
+      this.toast.show(message, 3000)
+    }
+  }
+
+  clearStatus = (groupId: string) => () => {
+    this.props.clearGroupStatus(groupId)
+  }
+
+  keyExtractor = (group: GroupStatus) => group.groupId
+
+  renderRow = ({ item }: ListRenderItemInfo<GroupStatus>) => {
+    const {
+      groupId,
+      numberComplete,
+      numberTotal,
+      sizeComplete,
+      sizeTotal,
+      error
+    } = item
+    const subtitle = `${numberComplete}/${numberTotal} files, ${sizeComplete}/${sizeTotal} bytes`
+    let rightItems: JSX.Element[] | undefined
+    if (error) {
+      rightItems = [
+        <TouchableOpacity
+          key="alert"
+          onPress={this.showError(`${error.id} : ${error.reason}`)}
+        >
+          <Icon name="alert-circle" size={size._024} color={color.severe_3} />
+        </TouchableOpacity>,
+        <TouchableOpacity key="clear" onPress={this.clearStatus(groupId)}>
+          <Icon name="circle-x" size={size._024} color={color.grey_4} />
+        </TouchableOpacity>
+      ]
+    }
+    return (
+      <ListItem
+        title={item.groupId}
+        subtitle={subtitle}
+        rightItems={rightItems}
+      />
+    )
+  }
+
+  render() {
+    return (
+      <View style={{ flex: 1, backgroundColor: color.screen_primary }}>
+        <FlatList
+          data={this.props.groupStatuses}
+          keyExtractor={this.keyExtractor}
+          renderItem={this.renderRow}
+          ItemSeparatorComponent={RowSeparator}
+        />
+        <Toast
+          ref={toast => {
+            this.toast = toast ? toast : undefined
+          }}
+          position="center"
+        />
+      </View>
+    )
+  }
+}
+
+function mapStateToProps(state: RootState): StateProps {
+  return {
+    groupStatuses: groupSelectors.fileSyncSelectors.groupStatuses(
+      state.group.fileSync
+    )
+  }
+}
+
+function mapDispatchToProps(dispatch: Dispatch<RootAction>): DispatchProps {
+  return {
+    clearGroupStatus: (groupId: string) =>
+      dispatch(groupActions.fileSync.clearStatus(groupId))
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(FileSync)

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
       }
     },
     "rules": {
+      "no-sync": 0,
       "no-undefined": 0,
       "default-case": 0,
       "react/no-string-refs": 1,


### PR DESCRIPTION
Lets us monitor file sync in verbose ui mode. Any errors are displayable by tapping the alert icon. Once something is in a error state, that is the end of the road for that item (for now anyway), so you can clear it from the redux state by tapping the 'x' icon.
<img width="400" alt="Screen Shot 2019-07-25 at 18 14 22" src="https://user-images.githubusercontent.com/528969/61914979-85c30980-af10-11e9-8aba-43bfc5639761.png">
