### PR TITLE
Fix inability to resubmit create new thread modal

### DIFF
--- a/App/Components/CreateThreadModal.tsx
+++ b/App/Components/CreateThreadModal.tsx
@@ -49,15 +49,21 @@ type Props = DispatchProps & ScreenProps
 
 interface State {
   value: string
-  submitted: boolean
 }
 
 class CreateThreadComponent extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
-      value: props.defaultName ? props.defaultName : '',
-      submitted: false
+      value: props.defaultName ? props.defaultName : ''
+    }
+  }
+
+  componentdidUpdate() {
+    if (this.props.defaultName && this.props.defaultName !== this.state.value) {
+      this.setState({
+        value: this.props.defaultName
+      })
     }
   }
 
@@ -67,10 +73,6 @@ class CreateThreadComponent extends React.Component<Props, State> {
 
   create() {
     return () => {
-      if (this.state.submitted) {
-        return
-      }
-      this.setState({ submitted: true })
       this.props.completeScreen(this.state.value)
       const name = this.state.value
       const type =
@@ -89,6 +91,9 @@ class CreateThreadComponent extends React.Component<Props, State> {
         Boolean(this.props.navigateTo),
         Boolean(this.props.selectToShare)
       )
+      this.setState({
+        value: this.props.defaultName ? this.props.defaultName : ''
+      })
       this.props.complete()
     }
   }

--- a/App/Components/CreateThreadModal.tsx
+++ b/App/Components/CreateThreadModal.tsx
@@ -11,13 +11,17 @@ import Modal from 'react-native-modal'
 
 import { Thread } from '@textile/react-native-sdk'
 
-import { RootAction } from '../Redux/Types'
+import { RootState, RootAction } from '../Redux/Types'
 import PhotoViewingActions from '../Redux/PhotoViewingRedux'
 import PreferencesActions, { TourScreens } from '../Redux/PreferencesRedux'
 import Input from '../SB/components/Input'
 
 // Styles
 import styles from './Styles/ThreadCreateModal'
+
+interface StateProps {
+  alreadyAddingThread: boolean
+}
 
 interface DispatchProps {
   completeScreen: (threadName: string) => void
@@ -45,7 +49,7 @@ interface ScreenProps {
   complete: () => void
 }
 
-type Props = DispatchProps & ScreenProps
+type Props = StateProps & DispatchProps & ScreenProps
 
 interface State {
   value: string
@@ -99,7 +103,8 @@ class CreateThreadComponent extends React.Component<Props, State> {
   }
 
   render() {
-    const submitDisabled = !(this.state.value.length > 0)
+    const submitDisabled =
+      this.props.alreadyAddingThread || !(this.state.value.length > 0)
     return (
       <Modal
         isVisible={this.props.isVisible}
@@ -191,7 +196,13 @@ const mapDispatchToProps = (
   }
 }
 
+const mapStateToProps = (state: RootState): StateProps => {
+  return {
+    alreadyAddingThread: Boolean(state.photoViewing.addingThread)
+  }
+}
+
 export default connect(
-  undefined,
+  mapStateToProps,
   mapDispatchToProps
 )(CreateThreadComponent)

--- a/App/Components/CreateThreadModal.tsx
+++ b/App/Components/CreateThreadModal.tsx
@@ -132,6 +132,7 @@ class CreateThreadComponent extends React.Component<Props, State> {
                   style={styles.inputStyle}
                   value={this.state.value}
                   label={this.state.value === '' ? 'Add title...' : ''}
+                  disabled={this.props.alreadyAddingThread}
                   onChangeText={this.handleNewText}
                 />
               </View>


### PR DESCRIPTION
This is a quick fix for #1240. This issue was caused by a flag in the modal's state, `submitted`, which disables the new thread functionality. It is set to `true` the first time a new thread is created, and then never reset, causing the modal to silently fail. But really, I think we should address these issues:

- Should this really be a modal? Since several other screens need to navigate to this page, and it is pretty complex, I think it might make sense to refactor it into its own navigable screen. That would simplify solving some of the problems below.
- Most of the redux state uses an indexed type for pending requests (like adding or removing a contact, ignoring a block, etc.) so that multiple requests can be theoretically handled at once. It appears that the new thread functionality only supports one new thread at a time, which makes the logic simpler, but confusing considering that it is theoretically possible to have multiple pending new thread requests at once, and other parts of the application have already solved the issue of multiple requests pretty nicely.
- Right now, the new thread modal is automatically exiting when the new thread request is submitted. So there's nowhere to display errors/issues, and the user can theoretically get navigated to the new thread at any time even after they've closed the modal (when the saga completes). Instead of passing `navigateTo` as a boolean to the action/saga, we should really support adding a callback that resets the modal/closes it upon completion, as we do for another modal in the application. Making this into an indexed screen instead of a modal would make solving this problem a lot easier and make a callback (which feels dirty to me since `redux-saga` was created to get rid of them) unnecessary.

Hope this makes sense.