### PR TITLE
put it back to large ci machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
     working_directory: ~/textile-mobile
     docker:
       - image: circleci/android:api-28-node8-alpha
-    resource_class: xlarge
+    resource_class: large
     steps:
       - restore_cache: # If any cache exists, it'll way speedup these checkouts
           keys:


### PR DESCRIPTION
using an xl instance was mainly to eliminate the possibility of machine memory being a problem. I don't think that was the issue, so putting it back to large again.