### PR TITLE
Adds visual hierarchy to comments versus in-line group messages

### DIFF
--- a/App/Components/comments.tsx
+++ b/App/Components/comments.tsx
@@ -22,6 +22,27 @@ const VIEW_ALL: TextStyle = {
   marginTop: spacing._008
 }
 
+const MARGIN_BAR: ViewStyle = {
+  width: 4,
+  marginTop: 6,
+  marginLeft: 2,
+  marginRight: 8,
+  borderRadius: 3
+}
+
+// Uses text in order to nicely match the line-height when 1 comment.
+const MARGIN_BAR_FILL: TextStyle = {
+  ...textStyle.body_m,
+  lineHeight: 10,
+  flex: 1,
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  overflow: 'visible',
+  paddingTop: spacing._008,
+  backgroundColor: color.grey_5,
+  color: 'rgba(0,0,0,0)',
+}
+
 export interface CommentData {
   id: string
   username: string
@@ -60,6 +81,16 @@ const Comments = (props: Props) => {
     })
   return (
     <View style={[CONTAINER, props.commentsContainerStyle]}>
+      {props.comments.length > 0 &&
+        <View style={{flex: 1, flexDirection: 'row'}}>
+          <View style={MARGIN_BAR}>
+            <Text style={MARGIN_BAR_FILL}>0</Text>
+          </View>
+          <View style={{flex: 1, flexDirection: 'column'}}>
+            {comments}
+          </View>
+        </View>
+      }
       {displayCount < props.comments.length && (
         <TouchableOpacity onPress={props.onViewComments}>
           <Text style={VIEW_ALL}>{`See all ${
@@ -67,7 +98,6 @@ const Comments = (props: Props) => {
           } comments...`}</Text>
         </TouchableOpacity>
       )}
-      {comments}
     </View>
   )
 }


### PR DESCRIPTION
related to https://github.com/textileio/photos/issues/1228

Just adds a small indent and connecting line to photo comments so you can easily distinguish them from in-line group messages

![AndroidScreen](https://user-images.githubusercontent.com/370259/63368184-41216700-c332-11e9-8d0b-9d145d73945a.png)

![AndroidScreen2](https://user-images.githubusercontent.com/370259/63368190-441c5780-c332-11e9-9dc6-0182d75ec222.png)
