### PR TITLE
cleans up the invite flow, makes more obvious methods

### DIFF
--- a/App/Components/ListItem.tsx
+++ b/App/Components/ListItem.tsx
@@ -24,6 +24,7 @@ interface Props {
   onSelect?: () => void
   disabled?: boolean
   titleStyle?: TextStyle
+  invert?: boolean
 }
 
 class ListItem extends React.PureComponent<Props> {
@@ -52,7 +53,6 @@ class ListItem extends React.PureComponent<Props> {
         ]
       : []
     const leftItem = this.props.leftItem ? [this.props.leftItem] : []
-    const leftItems = [...checkbox, ...leftItem]
 
     const showDisclosure =
       (this.props.showDisclosure || false) && !(this.props.selecting || false)
@@ -66,7 +66,17 @@ class ListItem extends React.PureComponent<Props> {
           />
         ]
       : []
-    const rightItems = [...(this.props.rightItems || []), ...disclosureIcon]
+
+    let leftItems = []
+    let rightItems = []
+
+    if (this.props.invert) {
+      rightItems = [...checkbox]
+      leftItems = [...(this.props.rightItems || []), ...disclosureIcon, ...leftItem]
+    } else {
+      leftItems = [...checkbox, ...leftItem]
+      rightItems = [...(this.props.rightItems || []), ...disclosureIcon]
+    }
 
     return (
       <TouchableOpacity

--- a/App/Components/join.tsx
+++ b/App/Components/join.tsx
@@ -31,7 +31,10 @@ const META: ViewStyle = {
 }
 
 const USERNAME: TextStyle = {
-  ...textStyle.body_m_bold
+  ...textStyle.body_m_bold,
+  maxWidth: '75%',
+  overflow: 'hidden',
+  flexWrap: 'nowrap'
 }
 
 const MESSAGE: TextStyle = {
@@ -59,7 +62,7 @@ const Join = (props: Props) => {
       <Avatar style={AVATAR} target={props.avatar} />
       <View style={CONTENT}>
         <View style={META}>
-          <Text style={USERNAME}>
+          <Text numberOfLines={1} style={USERNAME}>
             {props.username} <Text style={MESSAGE}>{props.message}</Text>
           </Text>
           <Text style={TIME}>{props.time.toUpperCase()}</Text>

--- a/App/Redux/ThreadsRedux.ts
+++ b/App/Redux/ThreadsRedux.ts
@@ -5,14 +5,14 @@ const actions = {
   addExternalInviteRequest: createAction(
     'ADD_EXTERNAL_INVITE_REQUEST',
     resolve => {
-      return (id: string, name: string) => resolve({ id, name })
+      return (id: string, name: string, target?: string) => resolve({ id, name, target })
     }
   ),
   addExternalInviteSuccess: createAction(
     'ADD_EXTERNAL_INVITE_SUCCESS',
     resolve => {
-      return (id: string, name: string, invite: IExternalInvite) =>
-        resolve({ id, name, invite })
+      return (id: string, name: string, invite: IExternalInvite, target?: string) =>
+        resolve({ id, name, invite, target })
     }
   ),
   addExternalInviteError: createAction('ADD_EXTERNAL_INVITE_ERROR', resolve => {

--- a/App/SB/views/ThreadsEditFriends/index.tsx
+++ b/App/SB/views/ThreadsEditFriends/index.tsx
@@ -34,12 +34,26 @@ class Component extends React.Component<Props> {
     showQrCode: false
   }
 
-  _getPublicLink() {
+  getPublicLink = () => {
     // Generate a link dialog
     this.props.invite(this.props.threadId, this.props.threadName)
   }
 
-  _displayThreadQRCode() {
+  findNearby = () => {
+    // @ts-ignore
+    this.refs.toast.show('Please enable Airdrop', 1600)
+    // Generate a link dialog
+    this.props.invite(this.props.threadId, this.props.threadName)
+  }
+
+  copyToClipboard = () => {
+    // Copy link to clipboard
+    this.props.invite(this.props.threadId, this.props.threadName, 'clipboard')
+    // @ts-ignore
+    this.refs.toast.show('Success', 1200)
+  }
+
+  displayThreadQRCode = () => {
     // Generate a link dialog
     this.props.threadQRCodeRequest(this.props.threadId, this.props.threadName)
     this.setState({ showQrCode: true })
@@ -103,12 +117,11 @@ class Component extends React.Component<Props> {
       <View style={styles.container}>
         <View style={{ flex: 1, zIndex: 10 }}>
           <ContactSelect
-            /* tslint:disable-next-line jsx-no-bind */
-            displayQRCode={this._displayThreadQRCode.bind(this)}
-            /* tslint:disable-next-line jsx-no-bind */
-            getPublicLink={this._getPublicLink.bind(this)}
+            findNearby={this.findNearby}
+            copyToClipboard={this.copyToClipboard}
+            displayQRCode={this.displayThreadQRCode}
+            getPublicLink={this.getPublicLink}
             contacts={this.props.contacts}
-            /* tslint:disable-next-line jsx-no-bind */
             select={this._select.bind(this)}
             selected={this.state.selected}
             topFive={this.props.topFive}
@@ -199,14 +212,14 @@ const mapStateToProps = (
 }
 
 interface DispatchProps {
-  invite: (threadId: string, threadName: string) => void
+  invite: (threadId: string, threadName: string, target?: string) => void
   threadQRCodeRequest: (threadId: string, threadName: string) => void
   addInternalInvites: (threadId: string, inviteePks: string[]) => void
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<RootAction>): DispatchProps => ({
-  invite: (threadId: string, threadName: string) => {
-    dispatch(ThreadsActions.addExternalInviteRequest(threadId, threadName))
+  invite: (threadId: string, threadName: string, target?: string) => {
+    dispatch(ThreadsActions.addExternalInviteRequest(threadId, threadName, target))
   },
   threadQRCodeRequest: (threadId: string, threadName: string) => {
     dispatch(ThreadsActions.threadQRCodeRequest(threadId, threadName))

--- a/App/SB/views/ThreadsEditFriends/statics/styles.js
+++ b/App/SB/views/ThreadsEditFriends/statics/styles.js
@@ -1,5 +1,6 @@
 import { StyleSheet } from 'react-native'
 import { bentonSansBold } from '../../../util/fonts'
+import { color } from '../../../../styles';
 
 export default StyleSheet.create({
   container: {
@@ -12,13 +13,14 @@ export default StyleSheet.create({
     paddingHorizontal: 16
   },
   toast: {
-    backgroundColor: '#8e8e93'
+    backgroundColor: color.action_6
   },
   toastText: {
-    color: 'white',
+    color: color.grey_7,
     textAlign: 'center',
     fontSize: 18,
-    padding: 24
+    paddingHorizontal: 12,
+    paddingVertical: 2
   },
   buttons: {
     height: '15%',

--- a/App/Sagas/ThreadsSagas.ts
+++ b/App/Sagas/ThreadsSagas.ts
@@ -1,4 +1,4 @@
-import { Share } from 'react-native'
+import { Share, Clipboard } from 'react-native'
 import { delay } from 'redux-saga'
 import { call, put, select, fork } from 'redux-saga/effects'
 import ThreadsActions from '../Redux/ThreadsRedux'
@@ -51,10 +51,10 @@ function* joinOnFork(inviteId: string, key: string) {
 export function* addExternalInvite(
   action: ActionType<typeof ThreadsActions.addExternalInviteRequest>
 ) {
-  const { id, name } = action.payload
+  const { id, name, target } = action.payload
   try {
     const invite: IExternalInvite = yield call(Textile.invites.addExternal, id)
-    yield put(ThreadsActions.addExternalInviteSuccess(id, name, invite))
+    yield put(ThreadsActions.addExternalInviteSuccess(id, name, invite, target))
   } catch (error) {
     yield put(ThreadsActions.addExternalInviteError(id, error))
   }
@@ -77,8 +77,12 @@ export function* displayThreadQRCode(
 export function* presentShareInterface(
   action: ActionType<typeof ThreadsActions.addExternalInviteSuccess>
 ) {
-  const { invite, name } = action.payload
+  const { invite, name, target } = action.payload
   const link = DeepLink.createInviteLink(invite, name)
+  if (target && target === 'clipboard') {
+    yield call(Clipboard.setString, link)
+    return
+  }
   yield call(Share.share, {
     title: 'Join my thread on Textile!',
     message: link


### PR DESCRIPTION
While playing with multipeer I realized that we already solve the first use case, invite nearby. It's part of the native share in ios anyway. So realized that a small UI tweak could just make it more obvious for now.

Previously,

![IMG_877C2926DB6F-1](https://user-images.githubusercontent.com/370259/63614960-19800800-c599-11e9-8de0-631fd6d7295d.jpeg)

Now,

![Screen Shot 2019-08-23 at 11 15 33 AM](https://user-images.githubusercontent.com/370259/63614975-2270d980-c599-11e9-8dbe-273283984ec0.png)

Adds an explicit method for Nearby in iOS. Also makes copy it's own button instead of hidden in the native share. Finally, it reuses the List element from the Contacts screens for a bit of consistency. 


