### PR TITLE
adds a deeplink routes for direct cafe invites

### DIFF
--- a/App/Sagas/DeepLinkSagas.ts
+++ b/App/Sagas/DeepLinkSagas.ts
@@ -20,6 +20,11 @@ import { PreferencesSelectors } from '../Redux/PreferencesRedux'
 import AuthActions, { AuthSelectors } from '../Redux/AuthRedux'
 import StartupActions, { startupSelectors } from '../Redux/StartupRedux'
 import { logNewEvent } from './DeviceLogs'
+import { cafesActions, cafesSelectors } from '../features/cafes';
+import { NavigationActions } from 'react-navigation';
+import { Cafe } from '@textile/js-types';
+import { RootState } from '../Redux/Types';
+import { showPrompt } from '../features/cafes/sagas';
 
 export function* inviteAfterOnboard() {
   const invite = yield select(AuthSelectors.invite)
@@ -51,6 +56,39 @@ export function* routeThreadInvite(url: string, hash: string) {
   }
 }
 
+
+export function* routeCafeInvite(url: string, hash: string) {
+  const reduxStarted: boolean = yield select(startupSelectors.started)
+  if (!reduxStarted) {
+    yield take(getType(StartupActions.startup))
+  }
+  if (yield select(PreferencesSelectors.onboarded)) {
+    const params = DeepLink.getParams(hash)
+    if (params.token && params.url && params.peerId) {
+      const cafes: Cafe[] = yield select((state: RootState) =>
+        cafesSelectors.registeredCafes(state.cafes)
+      )
+      if (cafes.find((cafe) => cafe.peer === params.peerId || cafe.url === params.url)) {
+        // no registration needed, silent ignore
+        return
+      }
+      try {
+        yield call(NavigationService.navigate, 'Cafes')
+        yield call(showPrompt, 'Storage Bot Invite', 'If you continue, you will send encrypted copies of your groups to this service. Be sure the bot is run by someone you trust. If you already have a lot of photos, consider joining when connected to WiFi.')
+        yield put(
+          cafesActions.registerCafe.request({
+            url: params.url as string,
+            peerId: params.peerId as string,
+            token: params.token as string
+          })
+        )
+      } catch(err) {
+        //silent pass
+      } 
+    }
+  }
+}
+
 export function* routeDeepLink(
   action: ActionType<typeof UIActions.routeDeepLinkRequest>
 ) {
@@ -71,6 +109,9 @@ export function* routeDeepLink(
         // NavigationService.navigate('PairingView', { request: DeepLink.getParams(data.hash) })
       } else if (data.path === '/invites/new' && data.hash !== '') {
         yield call(routeThreadInvite, standardUrl, data.hash)
+      } else if (data.path === '/invites/cafe' && data.hash !== '') {
+        // allow custom cafe invites
+        yield call(routeCafeInvite, standardUrl, data.hash)
       }
     }
   } catch (error) {


### PR DESCRIPTION
fixes https://github.com/textileio/photos/issues/1256

![IMG_4354](https://user-images.githubusercontent.com/370259/63622329-41786700-c5ab-11e9-9d0c-b7e7f11e3f6c.png)

^ not final text. 

This is for deeplink only and schema only support. It is in the form of,

`textile://www.textile.photos/invites/cafe#token=<cafe-token>&peerId=<cafe-peerId>&url=<cafe-url>`
