### PR TITLE
back to caching avatars

### DIFF
--- a/App/Components/Avatar.tsx
+++ b/App/Components/Avatar.tsx
@@ -210,28 +210,48 @@ class Avatar extends React.Component<Props, State> {
             uri: `${
               Config.RN_TEXTILE_GATEWAY_URL
             }/ipfs/${target}/0/small/content`,
-            cache: 'reload'
+            cache: 'force-cache'
           }}
           resizeMode={'cover'}
           onLoad={this.onHTTPLoad}
         >
-          {shouldShowIPFS && (
-            <TextileImage
-              style={{
-                minHeight: height,
-                minWidth: width,
-                alignSelf: 'center',
-                backgroundColor: 'transparent'
-              }}
-              target={`${target}/0/${resolution}/content`}
-              ipfs={true}
-              index={0}
-              forMinWidth={widthNumber}
-              resizeMode={'cover'}
-              onLayout={this.onImageLayout}
-              onError={this.onIPFSError}
-            />
-          )}
+          <ImageBackground
+            style={{
+              minHeight: height,
+              minWidth: width,
+              alignSelf: 'center',
+              backgroundColor:
+                this.props.style && this.props.style.backgroundColor
+                  ? this.props.style.backgroundColor
+                  : 'transparent'
+            }}
+            source={{
+              uri: `${
+                Config.RN_TEXTILE_GATEWAY_URL
+              }/ipfs/${target}/0/small/content`,
+              cache: 'reload'
+            }}
+            resizeMode={'cover'}
+            onLoad={this.onHTTPLoad}
+          >
+            {shouldShowIPFS && (
+              <TextileImage
+                style={{
+                  minHeight: height,
+                  minWidth: width,
+                  alignSelf: 'center',
+                  backgroundColor: 'transparent'
+                }}
+                target={`${target}/0/${resolution}/content`}
+                ipfs={true}
+                index={0}
+                forMinWidth={widthNumber}
+                resizeMode={'cover'}
+                onLayout={this.onImageLayout}
+                onError={this.onIPFSError}
+              />
+            )}
+          </ImageBackground>
         </ImageBackground>
       </View>
     )


### PR DESCRIPTION
a couple months back we had an avatar caching issue. my best guess of what was happening was that the cafes sent a 200s response that was actually an error (e.g. an html response). it led to some avatars turning grey and never recovering. they didn’t recover because that bunk response was cached in RN via a flag in the avatar image `cache='force-cache'`. 

to fix that issue we simply changed it back to, `cache='reload'` which flushed the bad results and everything worked again. Except that now the avatars do this little flash most times you load the screen. 

### solution 

To fix this, I'm going to put the flag back to `force-cache`. However, to avoid any issues like we hit last time, I'm going to just wrap an un-cached image with a cached one... The one in the background will be force-cache and the one over it will be `reload`. Ideally, we can remove the un-cached one in a later PR.